### PR TITLE
Contributed by Morgan Gangwere:

### DIFF
--- a/zimodem/wificlientnode.ino
+++ b/zimodem/wificlientnode.ino
@@ -193,7 +193,14 @@ int WiFiClientNode::flushOverflowBuffer()
 {
   if(overflowBufLen > 0)
   {
-    int bufWrite=client.write(overflowBuf,overflowBufLen);
+    // because overflowBuf is not a const char* for some reason
+    // we need to explicitly declare that we want one
+    // The simplest thing to do is pin down the first character of the
+    // array and call it a day.
+    // This avoids client.write<T>(buffer, length) from being seen by the
+    // compiler as a better way to poke at it. 
+    const uint8_t* overflowbuf_ptr = &overflowBuf[0];
+    int bufWrite=client.write(overflowbuf_ptr,overflowBufLen);
     if(bufWrite >= overflowBufLen)
     {
       overflowBufLen = 0;

--- a/zimodem/zlog.ino
+++ b/zimodem/zlog.ino
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 
+#include <cstdio>
+
 static char HD[3];
 static char HDL[9];
 
@@ -145,7 +147,7 @@ static void logPrintfln(const char* format, ...)
     int ret;
     va_list arglist;
     va_start(arglist, format);
-    vsprintf(FBUF, format, arglist);
+    vsnprintf(FBUF,sizeof(FBUF), format, arglist);
     logFile.println(FBUF);
     va_end(arglist);
   }
@@ -163,7 +165,7 @@ static void logPrintf(const char* format, ...)
     int ret;
     va_list arglist;
     va_start(arglist, format);
-    vsprintf(FBUF, format, arglist);
+    vsnprintf(FBUF, sizeof(FBUF), format, arglist);
     logFile.print(FBUF);
     va_end(arglist);
   }
@@ -194,5 +196,4 @@ static void logPrintln(const char* msg)
     logFile.println(msg);
   }
 }
-
 

--- a/zimodem/zserout.ino
+++ b/zimodem/zserout.ino
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 
+#include <cstring>
+
 static void serialDirectWrite(uint8_t c)
 {
   Serial.write(c);
@@ -217,7 +219,7 @@ void ZSerial::printf(const char* format, ...)
   int ret;
   va_list arglist;
   va_start(arglist, format);
-  vsprintf(FBUF, format, arglist);
+  vsnprintf(FBUF, sizeof(FBUF), format, arglist);
   prints(FBUF);
   va_end(arglist);
 }
@@ -284,4 +286,3 @@ char ZSerial::drainForXonXoff()
   }
   return ch;
 }
-


### PR DESCRIPTION
I've cleaned up some calls and made sure that the current version of the esp8266 library can be used to compile and run the whole thing.

There's a few places in v3 that call vsprintf() as well, and while cool it doesn't exist in the current Arduino environment, so I turned them into vsnprintf calls and made sure the buffer size is there.

For some reason, whitespace got consumed on commit ac36043 so I don't know what happened there.
  https://github.com/bozimmerman/Zimodem/pull/10

git-svn-id: svn://192.168.1.10/public/Zimodem@15621 0d6f1817-ed0e-0410-87c9-987e46238f29